### PR TITLE
write CRLF instead of escaped form for Newline

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -465,9 +465,9 @@ mod tests {
     #[test]
     fn test_newline_raw() {
         let test_data: [(&[u8], &[u8], &[u8]); 3] = [
-            (b"\r\nabc", br#"abc"#, b"\r\n"), // CLRF
-            (b"\nabc", b"abc", b"\n"),        // \n
-            (b"\rabc", b"abc", b"\r"),        // \r
+            (b"\r\nabc", br#"abc"#, b"\r\n"), // CRLF
+            (b"\nabc", b"abc", b"\n"),        // LF
+            (b"\rabc", b"abc", b"\r"),        // CR
         ];
         for (input, remaining_input, parsed_output) in test_data {
             assert_eq!(Ok((remaining_input, parsed_output)), newline_raw(input));
@@ -477,9 +477,9 @@ mod tests {
     #[test]
     fn test_newline_raw_invalid() {
         let test_data: [(&[u8], &[u8], ErrorKind); 3] = [
-            (b"a\r\nbc", b"a\r\nbc", ErrorKind::Tag), //CLRF
-            (b"a\nbc", b"a\nbc", ErrorKind::Tag),     // \n
-            (b"a\rbc", b"a\rbc", ErrorKind::Tag),     // \r
+            (b"a\r\nbc", b"a\r\nbc", ErrorKind::Tag), // CRLF
+            (b"a\nbc", b"a\nbc", ErrorKind::Tag),     // LF
+            (b"a\rbc", b"a\rbc", ErrorKind::Tag),     // CR
         ];
         for (input, remaining_input, error_kind) in test_data {
             assert_eq!(

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -112,7 +112,7 @@ impl Token {
             Token::Text(data) => data.to_vec(),
             Token::StartGroup => b"{".to_vec(),
             Token::EndGroup => b"}".to_vec(),
-            Token::Newline => b"\\r\\n".to_vec(),
+            Token::Newline => b"\r\n".to_vec(),
         }
     }
 


### PR DESCRIPTION
I wrote a tool that changes the font-size of existing RTF files. When using the `to_rtf()` method to write the new RTF I had to make a workaround to actually write out newlines, because the current code writes `\r\n` to the files instead of the actual CR LF ascii codes.